### PR TITLE
Fix selection of 10 minutes refresh rate

### DIFF
--- a/DevExcuses/Sources/Config/ConfigSheetController.swift
+++ b/DevExcuses/Sources/Config/ConfigSheetController.swift
@@ -44,6 +44,8 @@ final class ConfigSheetController: NSWindowController {
                 duration.selectItem(at: 3)
             } else if self.configs.duration == 300 {
                 duration.selectItem(at: 4)
+            } else if self.configs.duration == 600 {
+                duration.selectItem(at: 5)
             } else {
                 duration.selectItem(at: 0)
             }
@@ -157,6 +159,8 @@ final class ConfigSheetController: NSWindowController {
                 self.configs.duration = 120
             } else if duration.indexOfSelectedItem == 4 {
                 self.configs.duration = 300
+            } else if duration.indexOfSelectedItem == 5 {
+                self.configs.duration = 600
             }
         }
 


### PR DESCRIPTION
There is an issue with selecting 10 minutes refresh rate.
It's not saved and hence defaults to 15 seconds.

PS: I am not a Swift developer, for some reason when I build it to verify the fix, I can't get an actual executable :) So it's untested but I believe this is the fix :)